### PR TITLE
Standardize Lambda Handler Name

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -432,6 +432,7 @@
                 "sha256:8d4e9c88387b0f5c7d5f281e55304de64cf7f9c0021a3525bd3b1c542da3b0e4",
                 "sha256:9046c58c4395dff28dd494285c82ba00b546adfc7ef001486fbf0324bc174fba",
                 "sha256:9eb6caa9a297fc2c2fb8862bc5370d0303ddba53ba97e71f08023b6cd73d16a8",
+                "sha256:a08c6f0fe150303c1c6b71ebcd7213c2858041a7e01975da3a99aed1e7a378ef",
                 "sha256:a0cd17c15d3bb3fa06978b4e8958dcdc6e0174ccea823003a106c7d4d7899ac5",
                 "sha256:afd7e57eddb1a54f0f1a974bc4391af8bcce0b444685d936840f125cf046d5bd",
                 "sha256:b1275ad35a5d18c62a7220633c913e1b42d44b46ee12554e5fd39c70a243d6a3",
@@ -467,27 +468,27 @@
         },
         "ruff": {
             "hashes": [
-                "sha256:226b517f42d59a543d6383cfe03cccf0091e3e0ed1b856c6824be03d2a75d3b6",
-                "sha256:2f59bcf5217c661254bd6bc42d65a6fd1a8b80c48763cb5c2293295babd945dd",
-                "sha256:5f0312ba1061e9b8c724e9a702d3c8621e3c6e6c2c9bd862550ab2951ac75c16",
-                "sha256:6bbbc3042075871ec17f28864808540a26f0f79a4478c357d3e3d2284e832998",
-                "sha256:7a36fa90eb12208272a858475ec43ac811ac37e91ef868759770b71bdabe27b6",
-                "sha256:9a1600942485c6e66119da294c6294856b5c86fd6df591ce293e4a4cc8e72989",
-                "sha256:9ebb40442f7b531e136d334ef0851412410061e65d61ca8ce90d894a094feb22",
-                "sha256:9fb6b3b86450d4ec6a6732f9f60c4406061b6851c4b29f944f8c9d91c3611c7a",
-                "sha256:a623349a505ff768dad6bd57087e2461be8db58305ebd5577bd0e98631f9ae69",
-                "sha256:b13ba5d7156daaf3fd08b6b993360a96060500aca7e307d95ecbc5bb47a69296",
-                "sha256:dcaab50e278ff497ee4d1fe69b29ca0a9a47cd954bb17963628fa417933c6eb1",
-                "sha256:e261f1baed6291f434ffb1d5c6bd8051d1c2a26958072d38dfbec39b3dda7352",
-                "sha256:e3fd36e0d48aeac672aa850045e784673449ce619afc12823ea7868fcc41d8ba",
-                "sha256:e6894b00495e00c27b6ba61af1fc666f17de6140345e5ef27dd6e08fb987259d",
-                "sha256:ee3febce7863e231a467f90e681d3d89210b900d49ce88723ce052c8761be8c7",
-                "sha256:f57de973de4edef3ad3044d6a50c02ad9fc2dff0d88587f25f1a48e3f72edf5e",
-                "sha256:f988746e3c3982bea7f824c8fa318ce7f538c4dfefec99cd09c8770bd33e6539"
+                "sha256:1c8eca1a47b4150dc0fbec7fe68fc91c695aed798532a18dbb1424e61e9b721f",
+                "sha256:2270504d629a0b064247983cbc495bed277f372fb9eaba41e5cf51f7ba705a6a",
+                "sha256:269302b31ade4cde6cf6f9dd58ea593773a37ed3f7b97e793c8594b262466b67",
+                "sha256:62ce2ae46303ee896fc6811f63d6dabf8d9c389da0f3e3f2bce8bc7f15ef5488",
+                "sha256:653230dd00aaf449eb5ff25d10a6e03bc3006813e2cb99799e568f55482e5cae",
+                "sha256:6b3dadc9522d0eccc060699a9816e8127b27addbb4697fc0c08611e4e6aeb8b5",
+                "sha256:7060156ecc572b8f984fd20fd8b0fcb692dd5d837b7606e968334ab7ff0090ab",
+                "sha256:722bafc299145575a63bbd6b5069cb643eaa62546a5b6398f82b3e4403329cab",
+                "sha256:80258bb3b8909b1700610dfabef7876423eed1bc930fe177c71c414921898efa",
+                "sha256:87b3acc6c4e6928459ba9eb7459dd4f0c4bf266a053c863d72a44c33246bfdbf",
+                "sha256:96f76536df9b26622755c12ed8680f159817be2f725c17ed9305b472a757cdbb",
+                "sha256:a53d8e35313d7b67eb3db15a66c08434809107659226a90dcd7acb2afa55faea",
+                "sha256:ab3f71f64498c7241123bb5a768544cf42821d2a537f894b22457a543d3ca7a9",
+                "sha256:ad3f8088b2dfd884820289a06ab718cde7d38b94972212cc4ba90d5fbc9955f3",
+                "sha256:b2027dde79d217b211d725fc833e8965dc90a16d0d3213f1298f97465956661b",
+                "sha256:bea9be712b8f5b4ebed40e1949379cfb2a7d907f42921cf9ab3aae07e6fba9eb",
+                "sha256:e3d241aa61f92b0805a7082bd89a9990826448e4d0398f0e2bc8f05c75c63d99"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.7'",
-            "version": "==0.1.13"
+            "version": "==0.1.14"
         },
         "setuptools": {
             "hashes": [

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ resource "aws_lambda_function" "lambda_edge_geo_auth" {
   .
   .
   .
-  handler                        = "lambda_edge.lambda_handler"
+  handler                        = "lambda_edge.handler"
   .
   .
   .

--- a/docs/adrs/01-select-lambda-handler-name.md
+++ b/docs/adrs/01-select-lambda-handler-name.md
@@ -1,0 +1,26 @@
+# 1. Select the CDN Geo-Auth Lambda Handler Name
+
+Date: 2024-01-23
+
+## Status
+
+Accepted
+
+## Context
+
+Per the AWS documentation for [Lambda function handlers in Python](https://docs.aws.amazon.com/lambda/latest/dg/python-handler.html?icmpid=docs_lambda_help), we need to ensure that what Terraform defines for the handler when it create the Lambda function matches up with what the developer uses for a file name and function name in the dependent application repository.
+
+See ADR#9 in [mitlib-tf-workloads-libraries-website](https://github.com/MITLibraries/mitlib-tf-workloads-libraries-website) which says the exact same thing.
+
+See the conversation on [GDT-106](https://mitlibraries.atlassian.net/browse/GDT-106) for further details.
+
+## Decision
+
+1. The "custom domain" Lambda function handler is `handler`.
+2. The "custom domain" Lambda function filename in which the handler function lives is `lambda_edge.py`.
+
+The name of the handler that is used in the `resource "aws_lambda_function" "lambda_edge_geo_auth" {}` resource is `lambda_edge.handler`.
+
+## Consequences
+
+If anyone decides to rename Python files in this repo, then the definition of the Lambda function in the [mitlib-tf-workloads-libraries-website](https://github.com/MITLibraries/mitlib-tf-workloads-libraries-website) repo might need to be udpated.

--- a/lambdas/lambda_edge.py
+++ b/lambdas/lambda_edge.py
@@ -5,6 +5,6 @@ logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
 
 
-def lambda_handler(event: dict) -> str:
+def handler(event: dict) -> str:
     logger.debug(json.dumps(event))
     return "You have successfully called this lambda!"

--- a/tests/test_lambda_edge.py
+++ b/tests/test_lambda_edge.py
@@ -2,4 +2,4 @@ from lambdas import lambda_edge
 
 
 def test_lambda_edge():
-    assert lambda_edge.lambda_handler({}) == "You have successfully called this lambda!"
+    assert lambda_edge.handler({}) == "You have successfully called this lambda!"


### PR DESCRIPTION
### Purpose and background context

Align the file naming and function naming with the infrastructure updates in [mitlib-tf-workloads-libraries-website PR#50](https://github.com/MITLibraries/mitlib-tf-workloads-libraries-website/pull/50).

**Note**: The code currently in this repository does nothing! The actual Python code that is running in Dev1 and Stage-Workloads is a copy of the manually created jp-cdn-auth Lambda function from Dev1. EngX is still in the process of working through the initial dev/test work on this application in a different repo. The changes here line up this repo to be in excellent shape for EngX to load in code and test the standard dev/stage/prod deployment model without allowing Terraform to break anything.

#### How this addresses that need

- Add ADR#1 to capture the correct naming pattern for the main Python file and the function that is executed
- Replace all instances of `lambda_handler` with just `handler` in the code and tests
- Update README

### How can a reviewer manually see the effects of these changes?

There isn't a way to test the code that is in this application repo at this time. The development code that is currently running in Dev1 (and Stage-Workloads) was built separately and is not yet merged into this repository. To see how that code is working, simply try to load https://cdn.dev1.mitlibrary.net/geo/restricted/any_filename_you_want and you will be immediately redirected to a broken page (and this is the expected behavior at this point).

### What happens next

[PR#50](https://github.com/MITLibraries/mitlib-tf-workloads-libraries-website/pull/50) has been approved, but not yet merged to `stage` nor deployed in Stage-Workloads. There is also the pending [cf-lambda-custom-domain PR#5](https://github.com/MITLibraries/cf-lambda-custom-domain/pull/5) that needs to be approved. Once all three of these PRs are approved, the following will be the next steps.

1. Merge this approved PR to `main` and verify that the updated `.zip` file is pushed to the `shared-files-xxxx` S3 bucket in Stage-Workloads.
2. Merge [PR#5](https://github.com/MITLibraries/cf-lambda-custom-domain/pull/5) and verify that the updated `.zip` file is pushed to the `shared-files-xxxx` S3 bucket in Stage-Workloads.
3. Merge [PR#50](https://github.com/MITLibraries/mitlib-tf-workloads-libraries-website/pull/50) to `stage` and then deploy the updated infrastructure to Stage-Workloads.
4. Run through tests in Stage-Workloads to verify that everything is deployed and functioning as expected.

### Includes new or updated dependencies?

NO

### Changes expectations for external applications?

NO

### What are the relevant tickets?

- [GDT-118](https://mitlibraries.atlassian.net/browse/GDT-118)

### Developer

- [X] The `Dev CF Lambda@Edge Full Deploy` workflow has been run to update CloudFront in Dev1
- [X] All related Jira tickets are linked in commit message(s)
- [X] Stakeholder approval has been confirmed (or is not needed)

### Code Reviewer(s)

- [ ] The commit message is clear and follows our guidelines (not just this PR message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The provided documentation is sufficient for understanding any new functionality introduced
- [ ] Any manual tests have been performed and verified
- [ ] New dependencies are appropriate or there were no change


[GDT-118]: https://mitlibraries.atlassian.net/browse/GDT-118?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ