### PR TITLE
Configure Stage and Prod Deployment Automation

### DIFF
--- a/.github/workflows/prod-cf-deploy-lambda.yml
+++ b/.github/workflows/prod-cf-deploy-lambda.yml
@@ -1,0 +1,33 @@
+### This is the Terraform-generated GitHub Actions workflow for cf-lambda    ###
+### applications for dev/stage/prod. It will publish the Lambda zip to S3    ###
+### and optionally re-apply Terraform in the Terraform Cloud                 ###
+### workloads-libraries-website-<env> workspace.                             ###
+## Rename this workflow appropriately after copying to application repo
+name: Prod CF Lambda@Edge Full Deploy
+
+on:
+  workflow_dispatch:
+  release:
+    types: [published]
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  deploy-lambda:
+    ## We need to restrict this workflow to only run on releases on the main
+    ## branch while also allowing for manual runs in the GitHub web UI. The
+    ## GitHub context is different between releases and commits, so we have
+    ## to check two different values before we decide to run this.
+    if: ${{ github.ref == 'refs/heads/main' || github.event.release.target_commitish == 'main' }}
+    name: Push zip to S3 and Deploy CloudFront Distribution
+    uses: mitlibraries/.github/.github/workflows/cf-lambda-shared-deploy.yml@main
+    secrets: inherit
+    with:
+      AWS_REGION: us-east-1
+      ENVIRONMENT: prod
+      GHA_ROLE: ledge-geo-auth-gha-prod
+      TF_AUTO_APPLY: false
+      TF_WORKSPACE: workloads-libraries-website-prod
+      UPLOAD_ZIP: true

--- a/.github/workflows/stage-cf-deploy-lambda.yml
+++ b/.github/workflows/stage-cf-deploy-lambda.yml
@@ -1,0 +1,33 @@
+### This is the Terraform-generated GitHub Actions workflow for cf-lambda    ###
+### applications for dev/stage/prod. It will publish the Lambda zip to S3    ###
+### and optionally re-apply Terraform in the Terraform Cloud                 ###
+### workloads-libraries-website-<env> workspace.                             ###
+## Rename this workflow appropriately after copying to application repo
+name: Stage CF Lambda@Edge Full Deploy
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - ".github/**"
+      - "tests/**"
+
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  deploy-lambda:
+    name: Push zip to S3 and Deploy CloudFront Distribution
+    uses: mitlibraries/.github/.github/workflows/cf-lambda-shared-deploy.yml@main
+    secrets: inherit
+    with:
+      AWS_REGION: us-east-1
+      ENVIRONMENT: stage
+      GHA_ROLE: ledge-geo-auth-gha-stage
+      TF_AUTO_APPLY: true
+      TF_WORKSPACE: workloads-libraries-website-stage
+      UPLOAD_ZIP: true


### PR DESCRIPTION
### Purpose and background context

We are close enough to launch that it's time to prepare for automated deploys to Stage and Prod.

* Create stage deploy workflow (from TfCloud outputs from the mitlib-tf-workloads-libraries-website repo)
* Create prod deploy workflow (from TfCloud outputs from the mitlib-tf-workloads-libraries-website repo)

### How can a reviewer manually see the effects of these changes?

Since these are GitHub Actions, there really isn't a way to do any testing before these are in the `main` branch of the repository. That said, these files come from templates generated by Terraform and equivalent versions have been fully tested in another CDN-related app ([cf-lambda-custom-domain](https://github.com/MITLibraries/cf-lambda-custom-domain)).

### Includes new or updated dependencies?

NO

### Changes expectations for external applications?

NO

### What are the relevant tickets?

* https://mitlibraries.atlassian.net/browse/GDT-100

### Developer

- [x] The `Dev CF Lambda@Edge Full Deploy` workflow has been run to update CloudFront in Dev1
- [x] All related Jira tickets are linked in commit message(s)
- [x] Stakeholder approval has been confirmed (or is not needed)

### Code Reviewer(s)

- [x] The commit message is clear and follows our guidelines (not just this PR message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The provided documentation is sufficient for understanding any new functionality introduced
- [ ] Any manual tests have been performed and verified
- [x] New dependencies are appropriate or there were no change
